### PR TITLE
Update stdlib to support minijuvix examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,11 @@ jobs:
  
       - name : Typecheck library code
         run : |
-          minijuvix microjuvix typecheck --only-errors index.mjuvix
+          minijuvix microjuvix typecheck --only-errors --no-stdlib index.mjuvix
 
       - name: HTML
         run: |
-          minijuvix html index.mjuvix --theme ayu --recursive --print-metadata --output-dir=docs/
+          minijuvix html index.mjuvix --theme ayu --recursive --print-metadata --no-stdlib --output-dir=docs/
 
       - if: github.event.pull_request.merged == true
         name: Deploy HTML to github pages

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /docs/
+.minijuvix-build

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ all:
 
 PHONY: check
 check:
-	@minijuvix microjuvix typecheck index.mjuvix --only-errors
+	@minijuvix microjuvix typecheck index.mjuvix --only-errors --no-stdlib
 
 PHONY: html
 html:
 	make check
-	minijuvix html --output-dir=docs --recursive --print-metadata index.mjuvix
+	minijuvix html --output-dir=docs --recursive --print-metadata --no-stdlib index.mjuvix
 
 PHONY: clean
 clean:

--- a/Stdlib/Data/Bool.mjuvix
+++ b/Stdlib/Data/Bool.mjuvix
@@ -1,25 +1,66 @@
 module Stdlib.Data.Bool;
 
-  inductive Bool {
-    true : Bool;
-    false : Bool;
-  };
+inductive Bool {
+  true : Bool;
+  false : Bool;
+};
 
-  not : Bool → Bool;
-  not true ≔ false;
-  not false ≔ true;
+not : Bool → Bool;
+not true ≔ false;
+not false ≔ true;
 
-  infixr 2 ||;
-  || : Bool → Bool → Bool;
-  || false a ≔ a;
-  || true _ ≔ true;
+infixr 2 ||;
+|| : Bool → Bool → Bool;
+|| false a ≔ a;
+|| true _ ≔ true;
 
-  infixr 2 &&;
-  && : Bool → Bool → Bool;
-  && false _ ≔ false;
-  && true a ≔ a;
+infixr 2 &&;
+&& : Bool → Bool → Bool;
+&& false _ ≔ false;
+&& true a ≔ a;
 
-  if : {A : Type} → Bool → A → A → A;
-  if true a _ ≔ a;
-  if false _ b ≔ b;
+if : {A : Type} → Bool → A → A → A;
+if true a _ ≔ a;
+if false _ b ≔ b;
+
+--------------------------------------------------------------------------------
+-- Backend Booleans
+--------------------------------------------------------------------------------
+
+axiom BackendBool : Type;
+compile BackendBool {
+  c ↦ "bool";
+  ghc ↦ "Bool";
+};
+
+axiom backend-true : BackendBool;
+compile backend-true {
+  c ↦ "true";
+};
+
+axiom backend-false : BackendBool;
+compile backend-false {
+  c ↦ "false";
+};
+
+foreign ghc {
+  bool :: Bool -> a -> a -> a
+  bool True x _ = x
+  bool False _ y = y
+};
+
+foreign c {
+  void* boolInd(bool b, void* a1, void* a2) {
+    return b ? a1 : a2;
+  \}
+};
+
+axiom bool : BackendBool → Bool → Bool → Bool;
+compile bool {
+  c ↦ "boolInd";
+};
+
+from-backend-bool : BackendBool → Bool;
+from-backend-bool bb ≔ bool bb true false;
+
 end;

--- a/Stdlib/Data/List.mjuvix
+++ b/Stdlib/Data/List.mjuvix
@@ -12,6 +12,10 @@ inductive List (a : Type) {
   ∷ : a → List a → List a;
 };
 
+elem : {A : Type} → (A → A → Bool) → A → List A → Bool;
+elem _ _ nil ≔ false;
+elem eq s (x ∷ xs) ≔ eq s x || elem eq s xs;
+
 foldr : {A : Type} → {B : Type} → (A → B → B) → B → List A → B;
 foldr _ z nil ≔ z;
 foldr f z (h ∷ hs) ≔ f h (foldr f z hs);
@@ -67,6 +71,35 @@ infixr 5 ++;
 ++ : {A : Type} → List A → List A → List A;
 ++ nil ys ≔ ys;
 ++ (x ∷ xs) ys ≔ x ∷ (xs ++ ys);
+
+flatten : {A : Type} → List (List A) → List A;
+flatten ≔ foldl (++) nil;
+
+prependToAll : {A : Type} → A → List A → List A;
+prependToAll _ nil ≔ nil;
+prependToAll sep (x ∷ xs) ≔ sep ∷ x ∷ prependToAll sep xs;
+
+intersperse : {A : Type} → A → List A → List A;
+intersperse _ nil ≔ nil;
+intersperse sep (x ∷ xs) ≔ x ∷ prependToAll sep xs;
+
+head : {A : Type} → List A → A;
+head (x ∷ _) ≔ x;
+
+tail : {A : Type} → List A → List A;
+tail (_ ∷ xs) ≔ xs;
+
+terminating
+transpose : {A : Type} → List (List A) → List (List A);
+transpose (nil ∷ _) ≔ nil;
+transpose xss ≔ (map head xss) ∷ (transpose (map tail xss));
+
+any : {A : Type} → (A → Bool) → List A → Bool;
+any f xs ≔ foldl (||) false (map f xs);
+
+null : {A : Type} → List A → Bool;
+null nil ≔ true;
+null _ ≔ false;
 
 qsHelper : {A : Type} → A → List A × List A → List A;
 qsHelper a (l , r) ≔ l ++ (a ∷ nil) ++ r;

--- a/Stdlib/Data/Maybe.mjuvix
+++ b/Stdlib/Data/Maybe.mjuvix
@@ -9,4 +9,8 @@ fromMaybe : {A : Type} → A → Maybe A → A;
 fromMaybe a nothing ≔ a;
 fromMaybe _ (just a) ≔ a;
 
+maybe : {A : Type} → {B : Type} → B → (A → B) → Maybe A → B;
+maybe b _ nothing ≔ b;
+maybe _ f (just a) ≔ f a;
+
 end;

--- a/Stdlib/Data/Nat.mjuvix
+++ b/Stdlib/Data/Nat.mjuvix
@@ -1,11 +1,15 @@
 module Stdlib.Data.Nat;
 
+open import Stdlib.Data.String;
+
+builtin natural
 inductive ℕ  {
   zero : ℕ;
   suc : ℕ → ℕ;
 };
 
 infixl 6 +;
+builtin natural-plus
 + : ℕ → ℕ → ℕ;
 + zero b ≔ b;
 + (suc a) b ≔ suc (a + b);
@@ -14,5 +18,80 @@ infixl 7 *;
 * : ℕ → ℕ → ℕ;
 * zero b ≔ zero;
 * (suc a) b ≔ b + (a * b);
+
+one : ℕ;
+one ≔ suc zero;
+
+two : ℕ;
+two ≔ suc one;
+
+three : ℕ;
+three ≔ suc two;
+
+four : ℕ;
+four ≔ suc three;
+
+five : ℕ;
+five ≔ suc four;
+
+six : ℕ;
+six ≔ suc five;
+
+seven : ℕ;
+seven ≔ suc six;
+
+eight : ℕ;
+eight ≔ suc seven;
+
+nine : ℕ;
+nine ≔ suc eight;
+
+--------------------------------------------------------------------------------
+-- Int
+--------------------------------------------------------------------------------
+
+axiom Int : Type;
+compile Int {
+  c ↦ "int";
+};
+
+foreign c {
+   int plus(int l, int r) {
+     return l + r;
+   \}
+};
+
+infix 6 +int;
+axiom +int : Int -> Int -> Int;
+compile +int {
+  c ↦ "plus";
+};
+
+foreign c {
+  int natInd(int n, int a1, minijuvix_function_t* a2) {
+    if (n <= 0) return a1;
+    return ((int (*) (minijuvix_function_t*, int))a2->fun)(a2, natInd(n - 1, a1, a2));
+  \}
+};
+
+axiom natInd : Int → ℕ → (ℕ → ℕ) → ℕ;
+compile natInd {
+  c ↦ "natInd";
+};
+
+from-backendNat : Int → ℕ;
+from-backendNat bb ≔ natInd bb zero suc;
+
+axiom intToStr : Int → String;
+compile intToStr {
+  c ↦ "intToStr";
+};
+
+natToInt : ℕ → Int;
+natToInt zero ≔ 0;
+natToInt (suc n) ≔ 1 +int (natToInt n);
+
+natToStr : ℕ → String;
+natToStr n ≔ intToStr (natToInt n);
 
 end;

--- a/Stdlib/Data/Nat/Ord.mjuvix
+++ b/Stdlib/Data/Nat/Ord.mjuvix
@@ -2,11 +2,32 @@ module Stdlib.Data.Nat.Ord;
 
 open import Stdlib.Data.Nat;
 open import Stdlib.Data.Ord;
+open import Stdlib.Data.Bool;
 
 compare : ℕ → ℕ → Ordering;
 compare zero zero ≔ EQ;
 compare zero _ ≔ LT;
 compare (suc _) zero ≔ GT;
 compare (suc a) (suc b) ≔ compare a b;
+
+infix 4 ==;
+== : ℕ → ℕ → Bool;
+== a b ≔ isEQ (compare a b);
+
+infix 4 <;
+< : ℕ → ℕ → Bool;
+< a b ≔ isLT (compare a b);
+
+infix 4 <=;
+<= : ℕ → ℕ → Bool;
+<= a b ≔ not (isGT (compare a b));
+
+infix 4 >;
+> : ℕ → ℕ → Bool;
+> a b ≔ isGT (compare a b);
+
+infix 4 >=;
+>= : ℕ → ℕ → Bool;
+>= a b ≔ not (isLT (compare a b));
 
 end;

--- a/Stdlib/Data/Ord.mjuvix
+++ b/Stdlib/Data/Ord.mjuvix
@@ -16,6 +16,10 @@ isEQ : Ordering → Bool;
 isEQ EQ ≔ true;
 isEQ _ ≔ false;
 
+isGT : Ordering → Bool;
+isGT GT ≔ true;
+isGT _ ≔ false;
+
 ifOrd : {A : Type} → Ordering -> A → A → A → A;
 ifOrd LT lt eq gt ≔ lt;
 ifOrd EQ lt eq gt ≔ eq;

--- a/Stdlib/Data/String.mjuvix
+++ b/Stdlib/Data/String.mjuvix
@@ -8,20 +8,4 @@ compile String {
   c ↦ "char*";
 };
 
-foreign c {
-  bool cStrEq(char* l, char* r) {
-    return strcmp(l, r) == 0;
-  \}
-};
-
-axiom eqString : String → String → BackendBool;
-compile eqString  {
-  c ↦ "eqString";
-  ghc ↦ "(==)";
-};
-
--- infix 4 backend==;
--- backend== : String → String → Bool;
--- backend== s1 s2 ≔ from-backend-bool (cStrEq s1 s2);
-
 end;

--- a/Stdlib/Data/String/Ord.mjuvix
+++ b/Stdlib/Data/String/Ord.mjuvix
@@ -1,0 +1,21 @@
+module Stdlib.Data.String.Ord;
+
+open import Stdlib.Data.String;
+open import Stdlib.Data.Bool;
+
+foreign c {
+  bool cStrEq(char* l, char* r) {
+    return strcmp(l, r) == 0;
+  \}
+};
+
+axiom eqString : String → String → BackendBool;
+compile eqString  {
+  c ↦ "eqString";
+};
+
+infix 4 ==;
+== : String → String → Bool;
+== s1 s2 ≔ from-backend-bool (eqString s1 s2);
+
+end;

--- a/Stdlib/Prelude.mjuvix
+++ b/Stdlib/Prelude.mjuvix
@@ -1,12 +1,12 @@
 module Stdlib.Prelude;
 
-import Stdlib.Data.Bool;
-import Stdlib.Data.List.Ord;
-import Stdlib.Data.List;
-import Stdlib.Data.Nat.Ord;
-import Stdlib.Data.Nat;
-import Stdlib.Data.Ord;
-import Stdlib.Data.Product;
-import Stdlib.Function;
+open import Stdlib.Data.Bool public;
+open import Stdlib.Data.List public;
+open import Stdlib.Data.Maybe public;
+open import Stdlib.Data.Nat public;
+open import Stdlib.Data.Product public;
+open import Stdlib.Data.String public;
+open import Stdlib.Function public;
+open import Stdlib.System.IO public;
 
 end;

--- a/Stdlib/System/IO.mjuvix
+++ b/Stdlib/System/IO.mjuvix
@@ -1,0 +1,22 @@
+module Stdlib.System.IO;
+
+open import Stdlib.Data.Nat;
+open import Stdlib.Data.String;
+
+builtin IO axiom IO : Type;
+
+infixl 1 >>;
+builtin IO-sequence axiom >> : IO → IO → IO;
+builtin natural-print axiom printNat : ℕ → IO;
+
+axiom putStr : String → IO;
+compile putStr {
+  c ↦ "putStr";
+};
+
+axiom putStrLn : String → IO;
+compile putStrLn {
+  c ↦ "putStrLn";
+};
+
+end;

--- a/index.mjuvix
+++ b/index.mjuvix
@@ -11,6 +11,8 @@ Compiler: http://github.com/heliaxdev/minijuvix
 module index;
 
 import Stdlib.Prelude;
-import Stdlib.Function;
+import Stdlib.Data.Nat.Ord;
+import Stdlib.Data.List.Ord;
+import Stdlib.Data.String.Ord;
 
 end;


### PR DESCRIPTION
This PR should be merged after https://github.com/heliaxdev/minijuvix-stdlib/pull/4

Pass the `--no-stdlib` flag when typechecking and building the HTML output.